### PR TITLE
additional improvements and fixes

### DIFF
--- a/include/CPU.h
+++ b/include/CPU.h
@@ -13,6 +13,20 @@ class CPU {
   void initialize();
   void cycle();
 
+  // getters
+  Memory& get_memory();
+  Display& get_display();
+  Input& get_input();
+  uint8_t* get_registers();
+  uint8_t& get_vx(uint16_t opcode);
+  uint8_t& get_vy(uint16_t opcode);
+  uint16_t& get_I();
+  uint16_t& get_pc();
+  uint8_t& get_sp();
+  uint16_t* get_stack();
+  uint8_t& get_delay_timer();
+  uint8_t& get_sound_timer();
+
  private:
   // registers
   std::array<uint8_t, 16> V;       // general purpose registers (V0 to VF)
@@ -34,7 +48,24 @@ class CPU {
   uint8_t delay_timer;
   uint8_t sound_timer;
 
-  // fetch, decode and execute cycle
-  void fetch_decode_execute();
+  // opcode execution logic
   void process_opcode(uint16_t opcode);
 };
+
+// getters
+inline Memory& CPU::get_memory() { return memory; }
+inline Display& CPU::get_display() { return display; }
+inline Input& CPU::get_input() { return input; }
+inline uint8_t* CPU::get_registers() { return V.data(); }
+inline uint8_t& CPU::get_vx(uint16_t opcode) {
+  return V[(opcode & 0x0F00u) >> 8u];
+}
+inline uint8_t& CPU::get_vy(uint16_t opcode) {
+  return V[(opcode & 0x00F0u) >> 4u];
+}
+inline uint16_t& CPU::get_I() { return I; }
+inline uint16_t& CPU::get_pc() { return pc; }
+inline uint8_t& CPU::get_sp() { return sp; }
+inline uint16_t* CPU::get_stack() { return stack.data(); }
+inline uint8_t& CPU::get_delay_timer() { return delay_timer; }
+inline uint8_t& CPU::get_sound_timer() { return sound_timer; }

--- a/include/CPU.h
+++ b/include/CPU.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdint>
+#include <random>
 
 #include "display.h"
 #include "input.h"
@@ -12,6 +13,9 @@ class CPU {
   CPU(Memory& memory, Display& display, Input& input);
   void initialize();
   void cycle();
+
+  std::default_random_engine rand_gen;
+  std::uniform_int_distribution<uint8_t> rand_byte;
 
   // getters
   Memory& get_memory();

--- a/include/opcodes.h
+++ b/include/opcodes.h
@@ -242,6 +242,7 @@ inline void opcode_FX0A(CPU& cpu, uint16_t opcode) {
   }
   // if no key is pressed, do not proceed to the next instruction
   pc -= 2;
+  return;
 }
 
 // FX15: set the delay timer to the value of VX (LD DT, Vx)
@@ -266,7 +267,7 @@ inline void opcode_FX1E(CPU& cpu, uint16_t opcode) {
 // digit stored in VX (LD F, Vx)
 inline void opcode_FX29(CPU& cpu, uint16_t opcode) {
   uint8_t& VX = cpu.get_vx(opcode);
-  I = VX * 0x5;  // 5 bytes per character
+  I = 0x50 + VX * 0x5;  // 5 bytes per character
 }
 
 // FX33: store the binary-coded decimal representation of VX at the addresses I,
@@ -274,9 +275,16 @@ inline void opcode_FX29(CPU& cpu, uint16_t opcode) {
 inline void opcode_FX33(CPU& cpu, uint16_t opcode) {
   uint8_t& VX = cpu.get_vx(opcode);
 
-  memory.write(I, VX / 100);
-  memory.write(I + 1, (VX / 10) % 10);
-  memory.write(I + 2, (VX % 100) % 10);
+  // ones place
+  memory.write(I + 2, VX % 10);
+  VX /= 10;
+
+  // tens place
+  memory.write(I + 1, VX % 10);
+  VX /= 10;
+
+  // hundreds place
+  memory.write(I, VX % 10);
 }
 
 // FX55: store the values of V0 to VX in memory starting at address I (LD [I],

--- a/include/opcodes.h
+++ b/include/opcodes.h
@@ -1,0 +1,294 @@
+#pragma once
+
+#include <iostream>
+#include <random>
+
+#include "CPU.h"
+
+// 00E0: clear the screen (CLS)
+inline void opcode_00E0(CPU& cpu) { cpu.get_display().clear(); }
+
+// 00EE: return from a subroutine (RET)
+inline void opcode_00EE(CPU& cpu) {
+  cpu.get_pc() = cpu.get_stack()[cpu.get_sp()];
+  cpu.get_sp()--;
+}
+
+// 1NNN: jump to address NNN (JP addr)
+inline void opcode_1NNN(CPU& cpu, uint16_t opcode) {
+  cpu.get_pc() = opcode & 0x0FFFu;
+}
+
+// 2NNN: call subroutine at NNN (CALL addr)
+inline void opcode_2NNN(CPU& cpu, uint16_t opcode) {
+  cpu.get_sp()++;
+  cpu.get_stack()[cpu.get_sp()] = cpu.get_pc();
+  cpu.get_pc() = opcode & 0x0FFFu;
+}
+
+// 3XNN: skip next instruction if VX equals NN (SE Vx, byte)
+inline void opcode_3XNN(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t byte = opcode & 0x00FFu;
+
+  if (VX == byte) {
+    cpu.get_pc() += 2;
+  }
+}
+
+// 4XNN: skip next instruction if VX doesn't equal NN (SNE Vx, byte)
+inline void opcode_4XNN(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t byte = opcode & 0x00FFu;
+
+  if (VX != byte) {
+    cpu.get_pc() += 2;
+  }
+}
+
+// 5XY0: skip next instruction if VX equals VY (SE Vx, Vy)
+inline void opcode_5XY0(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t& VY = cpu.get_vy(opcode);
+
+  if (VX == VY) {
+    cpu.get_pc() += 2;
+  }
+}
+
+// 6XNN: set VX to NN (LD Vx, byte)
+inline void opcode_6XNN(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t byte = opcode & 0x00FFu;
+
+  VX = byte;
+}
+
+// 7XNN: add NN to VX (ADD Vx, byte)
+inline void opcode_7XNN(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t byte = opcode & 0x00FFu;
+
+  VX += byte;
+}
+
+// 8XY0: set VX to the value of VY (LD Vx, Vy)
+inline void opcode_8XY0(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t& VY = cpu.get_vy(opcode);
+
+  VX = VY;
+}
+
+// 8XY1: set VX to VX OR VY (OR Vx, Vy)
+inline void opcode_8XY1(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t& VY = cpu.get_vy(opcode);
+
+  VX |= VY;
+}
+
+// 8XY2: set VX to VX AND VY (AND Vx, Vy)
+inline void opcode_8XY2(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t& VY = cpu.get_vy(opcode);
+
+  VX &= VY;
+}
+
+// 8XY3: set VX to VX XOR VY (XOR Vx, Vy)
+inline void opcode_8XY3(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t& VY = cpu.get_vy(opcode);
+
+  VX ^= VY;
+}
+
+// 8XY4: add VY to VX, set VF to 1 if there's a carry, 0 otherwise (ADD Vx, Vy)
+inline void opcode_8XY4(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t& VY = cpu.get_vy(opcode);
+
+  (VY > (0xFF - VX)) ? cpu.get_registers()[0xF] = 1
+                     : cpu.get_registers()[0xF] = 0;
+
+  VX += VY;
+}
+
+// 8XY5: subtract VY from VX, set VF to 0 if there's a borrow, 1 otherwise (SUB
+// Vx, Vy)
+inline void opcode_8XY5(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t& VY = cpu.get_vy(opcode);
+
+  (VX > VY) ? cpu.get_registers()[0xF] = 1 : cpu.get_registers()[0xF] = 0;
+
+  VX -= VY;
+}
+
+// 8XY6: store the least significant bit of VX in VF and then shift VX to
+// the right by 1 (SHR Vx)
+inline void opcode_8XY6(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+
+  cpu.get_registers()[0xF] = VX & 0x1;
+  VX >>= 1;
+}
+
+// 8XY7: set VX to VY minus VX, set VF to 0 if there's a borrow, 1 otherwise
+inline void opcode_8XY7(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t& VY = cpu.get_vy(opcode);
+
+  (VY > VX) ? cpu.get_registers()[0xF] = 1 : cpu.get_registers()[0xF] = 0;
+
+  VX = VY - VX;
+}
+
+// 8XYE: store the most significant bit of VX in VF and then shift VX to the
+// left by 1 (SHL Vx {, Vy})
+inline void opcode_8XYE(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+
+  cpu.get_registers()[0xF] = VX >> 7;
+  VX <<= 1;
+}
+
+// 9XY0: skip next instruction if VX doesn't equal VY (SNE Vx, Vy)
+inline void opcode_9XY0(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t& VY = cpu.get_vy(opcode);
+
+  if (VX != VY) {
+    cpu.get_pc() += 2;
+  }
+}
+
+// ANNN: set I to the address NNN (LD I, addr)
+inline void opcode_ANNN(CPU& cpu, uint16_t opcode) {
+  cpu.get_I() = opcode & 0x0FFFu;
+}
+
+// BNNN: jump to the address NNN plus V0 (JP V0, addr)
+inline void opcode_BNNN(CPU& cpu, uint16_t opcode) {
+  cpu.get_pc() = (opcode & 0x0FFFu) + cpu.get_registers()[0];
+}
+
+// CXNN: set VX to the result of a random byte & NN (RND Vx, byte)
+inline void opcode_CXNN(CPU& cpu, uint16_t opcode) {
+  static std::random_device rd;
+  static std::mt19937 gen(rd());
+  static std::uniform_int_distribution<> dist(0, 255);
+
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t byte = opcode & 0x00FFu;
+
+  VX = dist(gen) & byte;
+}
+
+// DXYN: draw a sprite at position VX, VY with N bytes of sprite data starting
+inline void opcode_DXYN(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  uint8_t& VY = cpu.get_vy(opcode);
+
+  uint8_t x = VX;
+  uint8_t y = VY;
+  uint8_t height = opcode & 0x000Fu;
+  const uint8_t* sprite = cpu.get_memory().get_pointer(cpu.get_I());
+
+  bool collision = cpu.get_display().draw_sprite(x, y, sprite, height);
+  cpu.get_registers()[0xF] = collision ? 1 : 0;
+}
+
+// EX9E: skip next instruction if key with the value of VX is pressed (SKP Vx)
+inline void opcode_EX9E(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  if (cpu.get_input().is_key_down(VX)) {
+    cpu.get_pc() += 2;
+  }
+}
+
+// EXA1: skip next instruction if key with the value of VX is not pressed (SKNP
+// Vx)
+inline void opcode_EXA1(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  if (!cpu.get_input().is_key_down(VX)) {
+    cpu.get_pc() += 2;
+  }
+}
+
+// FX07: set VX to the value of the delay timer (LD Vx, DT)
+inline void opcode_FX07(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  VX = cpu.get_delay_timer();
+}
+
+// FX0A: wait for a key press and store the result in VX (LD Vx, K)
+inline void opcode_FX0A(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+
+  if (cpu.get_input().is_any_key_down()) {
+    for (int i = 0; i < 16; i++) {
+      if (cpu.get_input().is_key_down(i)) {
+        VX = i;
+        return;
+      }
+    }
+  } else {
+    cpu.get_pc() -= 2;
+  }
+}
+
+// FX15: set the delay timer to the value of VX (LD DT, Vx)
+inline void opcode_FX15(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  cpu.get_delay_timer() = VX;
+}
+
+// FX18: set the sound timer to the value of VX (LD ST, Vx)
+inline void opcode_FX18(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  cpu.get_sound_timer() = VX;
+}
+
+// FX1E: add the value of VX to I (ADD I, Vx)
+inline void opcode_FX1E(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  cpu.get_I() += VX;
+}
+
+// FX29: set I to the memory address of the sprite data corresponding to the hex
+// digit stored in VX (LD F, Vx)
+inline void opcode_FX29(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+  cpu.get_I() = VX * 0x5;  // 5 bytes per character
+}
+
+// FX33: store the binary-coded decimal representation of VX at the addresses I,
+// I+1, and I+2 (LD B, Vx)
+inline void opcode_FX33(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+
+  cpu.get_memory().write(cpu.get_I(), VX / 100);
+  cpu.get_memory().write(cpu.get_I() + 1, (VX / 10) % 10);
+  cpu.get_memory().write(cpu.get_I() + 2, (VX % 100) % 10);
+}
+
+// FX55: store the values of V0 to VX in memory starting at address I (LD [I],
+// Vx)
+inline void opcode_FX55(CPU& cpu, uint16_t opcode) {
+  uint8_t& VX = cpu.get_vx(opcode);
+
+  for (int i = 0; i <= VX; i++) {
+    cpu.get_memory().write(cpu.get_I() + i, cpu.get_registers()[i]);
+  }
+}
+
+// FX65: read V0 to VX with values from memory starting at address I (LD Vx,
+// [I])
+inline void opcode_FX65(CPU& cpu, uint16_t opcode) {
+  uint8_t VX = (opcode & 0x0F00u) >> 8u;
+  for (int i = 0; i <= VX; ++i) {
+    cpu.get_registers()[i] = cpu.get_memory().read(cpu.get_I() + i);
+  }
+}

--- a/include/opcodes.h
+++ b/include/opcodes.h
@@ -234,16 +234,14 @@ inline void opcode_FX07(CPU& cpu, uint16_t opcode) {
 inline void opcode_FX0A(CPU& cpu, uint16_t opcode) {
   uint8_t& VX = cpu.get_vx(opcode);
 
-  if (input.is_any_key_down()) {
-    for (int i = 0; i < 16; i++) {
-      if (input.is_key_down(i)) {
-        VX = i;
-        return;
-      }
+  for (int i = 0; i < 16; ++i) {
+    if (input.is_key_down(i)) {
+      VX = i;
+      return;
     }
-  } else {
-    pc -= 2;
   }
+  // if no key is pressed, do not proceed to the next instruction
+  pc -= 2;
 }
 
 // FX15: set the delay timer to the value of VX (LD DT, Vx)

--- a/include/opcodes.h
+++ b/include/opcodes.h
@@ -194,6 +194,7 @@ inline void opcode_CXNN(CPU& cpu, uint16_t opcode) {
 }
 
 // DXYN: draw a sprite at position VX, VY with N bytes of sprite data starting
+// TODO: review this opcode
 inline void opcode_DXYN(CPU& cpu, uint16_t opcode) {
   uint8_t& VX = cpu.get_vx(opcode);
   uint8_t& VY = cpu.get_vy(opcode);

--- a/include/opcodes.h
+++ b/include/opcodes.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <random>
-
 #include "CPU.h"
 
 // macros for easier access to CPU getters
@@ -183,18 +181,13 @@ inline void opcode_BNNN(CPU& cpu, uint16_t opcode) {
 
 // CXNN: set VX to the result of a random byte & NN (RND Vx, byte)
 inline void opcode_CXNN(CPU& cpu, uint16_t opcode) {
-  static std::random_device rd;
-  static std::mt19937 gen(rd());
-  static std::uniform_int_distribution<> dist(0, 255);
-
   uint8_t& VX = cpu.get_vx(opcode);
   uint8_t byte = opcode & 0x00FFu;
 
-  VX = dist(gen) & byte;
+  VX = cpu.rand_byte(cpu.rand_gen) & byte;
 }
 
 // DXYN: draw a sprite at position VX, VY with N bytes of sprite data starting
-// TODO: review this opcode
 inline void opcode_DXYN(CPU& cpu, uint16_t opcode) {
   uint8_t& VX = cpu.get_vx(opcode);
   uint8_t& VY = cpu.get_vy(opcode);

--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -2,13 +2,19 @@
 
 #include <stdint.h>
 
+#include <chrono>
 #include <iostream>
+#include <random>
 
 #include "display.h"
 #include "opcodes.h"
 
 CPU::CPU(Memory& memory, Display& display, Input& input)
-    : memory(memory), display(display), input(input) {
+    : memory(memory),
+      display(display),
+      input(input),
+      rand_gen(std::chrono::system_clock::now().time_since_epoch().count()) {
+  rand_byte = std::uniform_int_distribution<uint8_t>(0, 255);
   initialize();
 }
 

--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -33,6 +33,17 @@ void CPU::cycle() {
   // decode and execute
   pc += 2;
   process_opcode(opcode);
+
+  if (delay_timer > 0) {
+    --delay_timer;
+  }
+
+  if (sound_timer > 0) {
+    if (sound_timer == 1) {
+      // TODO: play sound
+    }
+    --sound_timer;
+  }
 }
 
 void CPU::process_opcode(uint16_t opcode) {

--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -31,9 +31,8 @@ void CPU::cycle() {
   uint16_t opcode = memory.read(pc) << 8 | memory.read(pc + 1);
 
   // decode and execute
-  std::cout << "Executing opcode: " << std::hex << opcode << std::endl;
-  process_opcode(opcode);
   pc += 2;
+  process_opcode(opcode);
 }
 
 void CPU::process_opcode(uint16_t opcode) {

--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -4,7 +4,10 @@
 
 #include <iostream>
 
-CPU::CPU(Memory &memory, Display &display, Input &input)
+#include "display.h"
+#include "opcodes.h"
+
+CPU::CPU(Memory& memory, Display& display, Input& input)
     : memory(memory), display(display), input(input) {
   initialize();
 }
@@ -23,201 +26,150 @@ void CPU::initialize() {
   sound_timer = 0;
 }
 
-void CPU::cycle() { fetch_decode_execute(); }
-
-void CPU::fetch_decode_execute() {
+void CPU::cycle() {
   // fetch instruction
   uint16_t opcode = memory.read(pc) << 8 | memory.read(pc + 1);
 
   // decode and execute
-  pc += 2;
+  std::cout << "Executing opcode: " << std::hex << opcode << std::endl;
   process_opcode(opcode);
+  pc += 2;
 }
 
 void CPU::process_opcode(uint16_t opcode) {
-  switch (opcode & 0xF000) {  // mask the opcode to get the first nibble
+  switch (opcode & 0xF000) {
     case 0x0000:
       switch (opcode & 0x00FF) {
-        case 0x00E0:  // 00E0: clear the screen
-          display.clear();
+        case 0x00E0:
+          opcode_00E0(*this);
           break;
-        case 0x00EE:  // 00EE: return from subroutine
-          pc = stack[sp];
-          sp--;
+        case 0x00EE:
+          opcode_00EE(*this);
           break;
         default:
-          std::cerr << "Unknown opcode: " << opcode << std::endl;
+          std::cerr << "Unknown opcode [0x0000]: " << opcode << std::endl;
           break;
       }
       break;
-    case 0x1000:  // 1NNN: JMP NNN
-      pc = opcode & 0x0FFFu;
+    case 0x1000:
+      opcode_1NNN(*this, opcode);
       break;
-    case 0x2000:  // 2NNN: CALL at NNN
-      sp++;
-      stack[sp] = pc;
-      pc = opcode & 0x0FFFu;
+    case 0x2000:
+      opcode_2NNN(*this, opcode);
       break;
-    case 0x3000:  // 3XNN: skip next instruction if VX = NN
-      if (V[(opcode & 0x0F00u) >> 8u] == (opcode & 0x00FFu)) {
-        pc += 2;
-      }
+    case 0x3000:
+      opcode_3XNN(*this, opcode);
       break;
-    case 0x4000:  // 4XNN: skip next instruction if VX != NN
-      if (V[(opcode & 0x0F00u) >> 8u] != (opcode & 0x00FFu)) {
-        pc += 2;
-      }
+    case 0x4000:
+      opcode_4XNN(*this, opcode);
       break;
-    case 0x5000:  // 5XY0: skip next instruction if VX = VY
-      if (V[(opcode & 0x0F00u) >> 8u] == V[(opcode & 0x00F0u) >> 4u]) {
-        pc += 2;
-      }
+    case 0x5000:
+      opcode_5XY0(*this, opcode);
       break;
-    case 0x6000:  // 6XNN: VX = NN
-      V[(opcode & 0x0F00u) >> 8u] = opcode & 0x00FFu;
+    case 0x6000:
+      opcode_6XNN(*this, opcode);
       break;
-    case 0x7000:  // 7XNN: VX += NN
-      V[(opcode & 0x0F00u) >> 8u] += opcode & 0x00FFu;
+    case 0x7000:
+      opcode_7XNN(*this, opcode);
       break;
-    case 0x8000:  // 8XYN: bitwise operations
+    case 0x8000:
       switch (opcode & 0x000F) {
-        case 0x0000:  // 8XY0: set VX = VY
-          V[(opcode & 0x0F00u) >> 8u] = V[(opcode & 0x00F0u) >> 4u];
+        case 0x0000:
+          opcode_8XY0(*this, opcode);
           break;
-        case 0x0001:  // 8XY1: set VX = (VX | VY)
-          V[(opcode & 0x0F00u) >> 8u] |= V[(opcode & 0x00F0u) >> 4u];
+        case 0x0001:
+          opcode_8XY1(*this, opcode);
           break;
-        case 0x0002:  // 8XY2: set VX = (VX & VY)
-          V[(opcode & 0x0F00u) >> 8u] &= V[(opcode & 0x00F0u) >> 4u];
+        case 0x0002:
+          opcode_8XY2(*this, opcode);
           break;
-        case 0x0003:  // 8XY3: set VX = (VX ^ VY)
-          V[(opcode & 0x0F00u) >> 8u] ^= V[(opcode & 0x00F0u) >> 4u];
+        case 0x0003:
+          opcode_8XY3(*this, opcode);
           break;
-        case 0x0004:  // 8XY4: set VX = VX + VY, set VF = carry
-          V[0xF] = (V[(opcode & 0x0F00u) >> 8u] >
-                    (0xFF - V[(opcode & 0x00F0u) >> 4u]))
-                       ? 1
-                       : 0;
-          V[(opcode & 0x0F00u) >> 8u] += V[(opcode & 0x00F0u) >> 4u];
+        case 0x0004:
+          opcode_8XY4(*this, opcode);
           break;
-        case 0x0005:  // 8XY5: set VX = VX - VY, set VF = NOT borrow
-          V[0xF] = (V[(opcode & 0x0F00u) >> 8u] > V[(opcode & 0x00F0u) >> 4u])
-                       ? 1
-                       : 0;
-          V[(opcode & 0x0F00u) >> 8u] -= V[(opcode & 0x00F0u) >> 4u];
+        case 0x0005:
+          opcode_8XY5(*this, opcode);
           break;
-        case 0x0006:  // 8XY6: set VX = VX >> 1, set VF = LSB of VX
-          V[0xF] = V[(opcode & 0x0F00u) >> 8u] & 0x1;
-          V[(opcode & 0x0F00u) >> 8u] >>= 1;
+        case 0x0006:
+          opcode_8XY6(*this, opcode);
           break;
-        case 0x0007:  // 8XY7: set VX = VY - VX, set VF = NOT borrow
-          V[0xF] = (V[(opcode & 0x00F0u) >> 4u] > V[(opcode & 0x0F00u) >> 8u])
-                       ? 1
-                       : 0;
-          V[(opcode & 0x0F00u) >> 8u] =
-              V[(opcode & 0x00F0u) >> 4u] - V[(opcode & 0x0F00u) >> 8u];
+        case 0x0007:
+          opcode_8XY7(*this, opcode);
           break;
-        case 0x000E:  // 8XYE: set VX = VX << 1, set VF = MSB of VX
-          V[0xF] = V[(opcode & 0x0F00u) >> 8u] >> 7;
-          V[(opcode & 0x0F00u) >> 8u] <<= 1;
+        case 0x000E:
+          opcode_8XYE(*this, opcode);
           break;
         default:
-          std::cerr << "Unknown opcode [8NNN] " << opcode << std::endl;
+          std::cerr << "Unknown opcode [0x8000]: " << opcode << std::endl;
           break;
       }
       break;
-    case 0x9000:  // 9XY0: skip next instruction if VX != VY
-      if (V[(opcode & 0x0F00u) >> 8u] != V[(opcode & 0x00F0u) >> 4u]) {
-        pc += 2;
-      }
+    case 0x9000:
+      opcode_9XY0(*this, opcode);
       break;
-    case 0xA000:  // ANNN: set I = NNN
-      I = opcode & 0x0FFFu;
+    case 0xA000:
+      opcode_ANNN(*this, opcode);
       break;
-    case 0xB000:  // BNNN: jump to NNN + V0
-      pc = (opcode & 0x0FFFu) + V[0];
+    case 0xB000:
+      opcode_BNNN(*this, opcode);
       break;
-    case 0xC000:  // CXNN: set VX = random byte AND NN
-      V[(opcode & 0x0F00u) >> 8u] = (rand() % 0xFF) & (opcode & 0x00FFu);
+    case 0xC000:
+      opcode_CXNN(*this, opcode);
       break;
-    case 0xD000: {  // DXYN: draw sprite at (VX, VY) and set VF = collision
-
-      uint8_t x = V[(opcode & 0x0F00u) >> 8u];
-      uint8_t y = V[(opcode & 0x00F0u) >> 4u];
-      uint8_t height = opcode & 0x000Fu;
-      const uint8_t *sprite = memory.get_pointer(I);
-
-      bool collision = display.draw_sprite(x, y, sprite, height);
-      V[0xF] = collision ? 1 : 0;
-    } break;
-    case 0xE000: {
-      switch (opcode & 0x00FFu) {
-        case 0x009E:  // EX9E: skip next instruction if key VX is pressed
-          if (input.is_key_down(V[(opcode & 0x0F00u) >> 8u])) {
-            pc += 2;
-          }
+    case 0xD000:
+      opcode_DXYN(*this, opcode);
+      break;
+    case 0xE000:
+      switch (opcode & 0x00FF) {
+        case 0x009E:
+          opcode_EX9E(*this, opcode);
           break;
-        case 0x00A1:  // EXA1: skip next instruction if key VX is not pressed
-          if (!input.is_key_down(V[(opcode & 0x0F00u) >> 8u])) {
-            pc += 2;
-          }
+        case 0x00A1:
+          opcode_EXA1(*this, opcode);
           break;
         default:
-          std::cerr << "Unknown opcode [ENNN] " << opcode << std::endl;
+          std::cerr << "Unknown opcode [0xE000]: " << opcode << std::endl;
           break;
       }
       break;
-    }
-    case 0xF000: {
-      switch (opcode & 0x00FFu) {
-        case 0x0007:  // FX07: set VX = delay timer
-          V[(opcode & 0x0F00u) >> 8u] = delay_timer;
+    case 0xF000:
+      switch (opcode & 0x00FF) {
+        case 0x0007:
+          opcode_FX07(*this, opcode);
           break;
-        case 0x000A:  // FX0A: wait for key press, store key in VX
-        {
-          bool key_pressed = false;
-          for (int i = 0; i < 16; ++i) {
-            if (input.is_key_down(i)) {
-              V[(opcode & 0x0F00u) >> 8u] = i;
-              key_pressed = true;
-            }
-          }
-        } break;
-        case 0x0015:  // FX15: set delay timer = VX
-          delay_timer = V[(opcode & 0x0F00u) >> 8u];
+        case 0x000A:
+          opcode_FX0A(*this, opcode);
           break;
-        case 0x0018:  // FX18: set sound timer = VX
-          sound_timer = V[(opcode & 0x0F00u) >> 8u];
+        case 0x0015:
+          opcode_FX15(*this, opcode);
           break;
-        case 0x001E:  // FX1E: set I = I + VX
-          I += V[(opcode & 0x0F00u) >> 8u];
+        case 0x0018:
+          opcode_FX18(*this, opcode);
           break;
-        case 0x0029:  // FX29: set I = location of sprite for digit VX
-          I = V[(opcode & 0x0F00u) >> 8u] * 0x5;
+        case 0x001E:
+          opcode_FX1E(*this, opcode);
           break;
-        case 0x0033:  // FX33: store BCD representation of VX in memory
-          memory.write(I, V[(opcode & 0x0F00u) >> 8u] / 100);
-          memory.write(I + 1, (V[(opcode & 0x0F00u) >> 8u] / 10) % 10);
-          memory.write(I + 2, V[(opcode & 0x0F00u) >> 8u] % 10);
+        case 0x0029:
+          opcode_FX29(*this, opcode);
           break;
-        case 0x0055:  // FX55: store V0 to VX in memory starting at address I
-          for (int i = 0; i <= ((opcode & 0x0F00u) >> 8u); ++i) {
-            memory.write(I + i, V[i]);
-          }
+        case 0x0033:
+          opcode_FX33(*this, opcode);
           break;
-        case 0x0065:  // FX65: fill V0 to VX with values from memory starting at
-                      // address I
-          for (int i = 0; i <= ((opcode & 0x0F00u) >> 8u); ++i) {
-            V[i] = memory.read(I + i);
-          }
+        case 0x0055:
+          opcode_FX55(*this, opcode);
+          break;
+        case 0x0065:
+          opcode_FX65(*this, opcode);
+          break;
         default:
-          std::cerr << "Unknown opcode [FNNN] " << opcode << std::endl;
+          std::cerr << "Unknown opcode [0xF000]: " << opcode << std::endl;
           break;
       }
       break;
-    }
     default:
-      std::cerr << "Unknown opcode [general] " << opcode << std::endl;
+      std::cerr << "Unknown opcode [general]: " << opcode << std::endl;
       break;
   }
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1,5 +1,7 @@
 #include "input.h"
 
+#include <SDL2/SDL.h>
+
 #include "SDL_events.h"
 
 Input::Input() { key_state.fill(false); }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv) {
             current_time - last_cycle_time)
             .count();
 
-    if (elapsed_time > 1.0f / 300.0f) {
+    if (elapsed_time > 3.0f) {
       // update the last cycle time
       last_cycle_time = current_time;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,7 @@ int main(int argc, char** argv) {
 
   // main loop
   bool running = true;
+  auto last_cycle_time = std::chrono::high_resolution_clock::now();
   SDL_Event event;
 
   while (running) {
@@ -40,14 +41,23 @@ int main(int argc, char** argv) {
       }
     }
 
-    // execute one cycle of the CPU
-    cpu.cycle();
+    // get the current time
+    auto current_time = std::chrono::high_resolution_clock::now();
+    float elapsed_time =
+        std::chrono::duration<float, std::chrono::milliseconds::period>(
+            current_time - last_cycle_time)
+            .count();
 
-    // render the display
-    display.render();
+    if (elapsed_time > 1.0f / 300.0f) {
+      // update the last cycle time
+      last_cycle_time = current_time;
 
-    // delay to match the CHIP-8 speed (16ms for approx. 60Hz)
-    SDL_Delay(16);
+      // run the CPU
+      cpu.cycle();
+
+      // update the display
+      display.render();
+    }
   }
 
   SDL_Quit();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
     display.render();
 
     // delay to match the CHIP-8 speed (16ms for approx. 60Hz)
-    SDL_Delay(3);
+    SDL_Delay(16);
   }
 
   SDL_Quit();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
     display.render();
 
     // delay to match the CHIP-8 speed (16ms for approx. 60Hz)
-    SDL_Delay(16);
+    SDL_Delay(3);
   }
 
   SDL_Quit();

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -26,10 +26,10 @@ void Memory::load_rom(const char* filename) {
   }
 }
 
-// method to load fontset into memory
+// method to load fontset into memory (starts at 0x50)
 void Memory::load_font() {
   for (size_t i = 0; i < fontset.size(); i++) {
-    memory[i] = fontset[i];
+    memory[0x50 + i] = fontset[i];
   }
 }
 


### PR DESCRIPTION
this PR merges the `refactor` branch into `main`, bringing improvements such as:

- fixes  the `PC` (program counter) working flow, which enables the emulator to actually run games and programs (besides the Test `ROM`).
- detachment of  `opcode` logic from the main `CPU` logic, simplifying and better structuring the code.
- now correctly stores the CHIP-8 font in the memory.
- improvements to the emulator's update rate.
- fixes random number generation logic.

these changes mark the first **fully functional** version of this CHIP-8 emulator. 